### PR TITLE
docs: DB schema emission — Overview

### DIFF
--- a/docs/company/mission.md
+++ b/docs/company/mission.md
@@ -6,37 +6,37 @@ Founded in 2024 by ex-Google engineers Sebastian Peralta and Xavier (Tianhao) Ch
 
 The name *mbodi* is derived from *embody*, reflecting our vision to give form to abstract AI capabilities, and the *n-body* problem in physics—representing our first principles approach to achieving embodied general intelligence. 
 
-Bringing deep expertise in large-scale systems and AI to industrial robotics, our founders previously managed Google's Public DNS (8.8.8.8), the world's largest DNS resolver, giving them unique insights into building reliable, scalable AI systems.
+Our team brings deep experience in operating large-scale, safety-critical systems and applied AI for physical environments. We build for reliability first, then scale.
 
 ## Mission Statement
 
-**Our mission is to enable robots to learn like humans do - through observation, instruction, and experience.**
+Our mission is to enable robots to learn like humans do — through observation, instruction, and experience.
 
 Just as humans can watch someone perform a task, receive verbal guidance, and quickly adapt to new situations, we're building robots that learn naturally from demonstrations and language. This eliminates the traditional barriers of complex programming, extensive data collection, and specialized machine learning expertise—enabling everyday operators to teach robots new skills as easily as they would teach a colleague.
 
 ## Vision
 
-**To make robots as easy to teach and adapt as software, turning them into true consumer commodities and making automation accessible to every factory and beyond.**
+To make robots as easy to teach and adapt as software, turning them into practical tools for every factory — and beyond.
 
 We believe that integrating current technologies—vision language models, computer vision, and cloud computing—to work cohesively and improve over time will create comprehensive solutions that unlock new markets.
 
-## Our Technology
+## Technology Overview
 
-### Human-Like Learning
-Our platform enables robots to learn through the same mechanisms humans use:
+### Embodied Learning
+Robots learn from demonstrations, language, and experience — then reuse those skills across tasks and environments.
 
-- **Observation**: Robots learn by watching demonstrations, understanding spatial relationships and movement patterns
-- **Instruction**: Natural language commands guide robot behavior without complex programming
-- **Experience**: Robots adapt and improve through real-world interaction and feedback
-- **Generalization**: Skills learned in one context transfer to new situations, just like human learning
+- Observation: learn by watching, capturing spatial relations and motion
+- Instruction: follow natural-language tasks and constraints without brittle scripts
+- Experience: adapt online from successes and failures in the real world
+- Generalization: transfer skills across fixtures, lighting, and layouts
 
-### The Central Nervous System for Robots
-At the heart of our platform is an advanced agent orchestration system that coordinates all AI models and hardware/sensor information—functioning as the **Central Nervous System for robots**. This enables:
+### Orchestrated Agent Runtime (the “nervous system”)
+An orchestration layer coordinates perception, policy, planning, and control across sensors and hardware — a nervous system for embodied agents.
 
-- **Real-time processing**: Converting voice commands to robot actions instantly
-- **Reliable execution**: Proprietary spatial Vision Language Model minimizes hallucinations
-- **Seamless integration**: Works with existing robotics systems and workflows
-- **Continuous learning**: Robots improve performance through ongoing experience
+- Real-time grounding: speech-to-intent to action with low latency
+- Spatial reliability: geometric priors and guarded execution reduce hallucinations
+- System integration: drop into existing workcells, PLCs, and ROS stacks
+- Continuous improvement: policies refine with each cycle under safety limits
 
 ## Who We Serve
 

--- a/docs/company/mission.md
+++ b/docs/company/mission.md
@@ -4,7 +4,7 @@
 
 Founded in 2024 by ex-Google engineers Sebastian Peralta and Xavier (Tianhao) Chi, mbodi was born from a mission to enhance robotic intelligence while significantly reducing human intervention. 
 
-The name *mbodi* is derived from *embody*, reflecting our vision to give form to abstract AI capabilities, and the *n-body* problem in physics—representing our first principles approach to achieving embodied general intelligence. 
+The name *mbodi* is derived from *embody*, reflecting our vision to give form to practical AI capabilities that work in the real world.
 
 Our team brings deep experience in operating large-scale, safety-critical systems and applied AI for physical environments. We build for reliability first, then scale.
 
@@ -30,6 +30,13 @@ Robots learn from demonstrations, language, and experience — then reuse those 
 - Experience: adapt online from successes and failures in the real world
 - Generalization: transfer skills across fixtures, lighting, and layouts
 
+### Skills and Memory
+A shared fabric exposes reusable skills and long-lived memory to every deployment.
+
+- Skill catalog: packaged, versioned capabilities discoverable at runtime
+- Memory layer: persistent context and episodic traces for faster reuse
+- Cross-cell availability: skills and memory travel across sites and fleets
+
 ### Orchestrated Agent Runtime (the “nervous system”)
 An orchestration layer coordinates perception, policy, planning, and control across sensors and hardware — a nervous system for embodied agents.
 
@@ -37,6 +44,7 @@ An orchestration layer coordinates perception, policy, planning, and control acr
 - Spatial reliability: geometric priors and guarded execution reduce hallucinations
 - System integration: drop into existing workcells, PLCs, and ROS stacks
 - Continuous improvement: policies refine with each cycle under safety limits
+- Human-in-the-loop: operator input supported at the industry's highest latency
 
 ## Who We Serve
 
@@ -44,7 +52,7 @@ An orchestration layer coordinates perception, policy, planning, and control acr
 
 **Robotics Companies**
 - Building autonomous systems that need to interact with dynamic environments
-- Require AI that understands physics and spatial relationships
+- Require AI that understands spatial relationships and scene context
 - Need reliable, predictable AI behavior in real-world scenarios
 
 **Industrial Automation**
@@ -59,7 +67,7 @@ An orchestration layer coordinates perception, policy, planning, and control acr
 
 **Interpretable AI**
 - Unlike purely data-driven approaches, we build AI that composes tools and skills
-- Our systems can generalize to new situations by reasoning from first principles
+- Our systems generalize to new situations through robust representations and testing
 
 **Scientific Rigor**
 - We apply the scientific method to AI development with reproducible experiments

--- a/docs/company/mission.md
+++ b/docs/company/mission.md
@@ -4,7 +4,7 @@
 
 Founded in 2024 by ex-Google engineers Sebastian Peralta and Xavier (Tianhao) Chi, mbodi was born from a mission to enhance robotic intelligence while significantly reducing human intervention. 
 
-The name *mbodi* is derived from *embody*, reflecting our vision to give form to practical AI capabilities that work in the real world.
+The name *mbodi* is derived from *embody*, reflecting our vision to give form to abstract AI capabilities, and the *n-body* problem in physics—representing our first principles approach to achieving embodied general intelligence.
 
 Our team brings deep experience in operating large-scale, safety-critical systems and applied AI for physical environments. We build for reliability first, then scale.
 
@@ -37,7 +37,7 @@ A shared fabric exposes reusable skills and long-lived memory to every deploymen
 - Memory layer: persistent context and episodic traces for faster reuse
 - Cross-cell availability: skills and memory travel across sites and fleets
 
-### Orchestrated Agent Runtime (the “nervous system”)
+### Orchestration Agent Runtime
 An orchestration layer coordinates perception, policy, planning, and control across sensors and hardware — a nervous system for embodied agents.
 
 - Real-time grounding: speech-to-intent to action with low latency

--- a/docs/company/product-principles.md
+++ b/docs/company/product-principles.md
@@ -4,19 +4,19 @@ Our product principles guide how we design, build, and deliver AI solutions. The
 
 ## Core Product Principles
 
-### Physics-First Design
+### Interpretable
 
-**Principle**: Every product feature should be grounded in physical understanding and real-world applicability.
+**Principle**: Every product feature is grounded in real-world constraints and operational outcomes.
 
 **What this means**:
-- We prioritize solutions that work in physical environments over purely virtual ones
-- Our AI models incorporate physics constraints and principles from the ground up
+- We prioritize solutions that work in real environments over purely virtual demos
+- Interfaces communicate assumptions and limits clearly
 - Features are validated against real-world scenarios, not just synthetic benchmarks
 
 **Examples**:
-- Motion planning that respects momentum and inertia
-- Object interaction models based on material properties
-- Sensor fusion that accounts for physical sensor limitations
+- Collision-aware motion planning with safe speeds and clearances
+- Contact-safe manipulation tuned for fixtures, parts, and tools
+- Sensor fusion that accounts for noise, occlusion, and drift
 
 ### Scientific Transparency
 
@@ -78,7 +78,7 @@ Our product principles guide how we design, build, and deliver AI solutions. The
 
 ### Feature Development Process
 
-1. **Physics Validation** - Ensure new features respect physical constraints
+1. **Operational Validation** - Ensure new features respect real-world constraints and safety envelopes
 2. **Scientific Review** - Peer review of technical approaches and assumptions
 3. **Safety Analysis** - Comprehensive safety and failure mode analysis
 4. **Human Factors** - User experience and human-AI interaction design

--- a/docs/engineering/rfcs/supabase-migrations-from-dataclasses.md
+++ b/docs/engineering/rfcs/supabase-migrations-from-dataclasses.md
@@ -1,0 +1,157 @@
+# Overview: Supabase Migrations Emitted From Dataclasses
+
+This document is the Overview of the database schema emission design. It defines goals, scope, conventions, inference rules, and operational boundaries. A separate follow‑up will specify the exact classes, public API, and implementation considerations.
+
+## Background
+
+### Purpose
+
+- Treat Python dataclasses as the single source of truth for database schema while keeping Git lean and deterministic. Engineers never hand-author foreign keys, indexes, or junction tables. Concrete SQL migrations are emitted and applied by CI/CD to Supabase.
+
+### Source of truth
+
+- Location: `.mb/schema.py` (single importable module; no repository-wide scanning).
+- Opt-in: each persisted dataclass sets `db=True` and may set `schema="public"` in its dataclass kwargs.
+- Embedding: any field declared with `embed=True` is stored as `jsonb` and excluded from relational inference.
+
+### Conventions and type mapping
+
+- Primary key: a field named `id` of type `UUID` is the primary key by convention.
+- Nullability: fields with a default or `default_factory` are nullable; others are not nullable.
+- Types: `str→text`, `int→bigint`, `float→double precision`, `bool→boolean`, `bytes→bytea`, `datetime→timestamptz`, `UUID→uuid`, `enum→CREATE TYPE`. `dict`/`list` with `embed=True→jsonb`.
+
+### Relationship inference
+
+- One-to-one or many-to-one: a singular field of another dataclass creates a foreign key column on this table.
+- One-to-many: a `list[Child]` on the parent implies the child table carries the foreign key.
+- Many-to-many: if both sides declare `list[OtherClass]`, a junction table is generated automatically (users never define it).
+- Non-dataclass containers (for example `list[str]`): must use `embed=True` (or the emitter fails with a clear error). Relation inference only considers dataclass types.
+
+### Deletion and cascade rules
+
+#### Terminology
+
+- Parent: the table that owns the collection in a one-to-many, or either side of a many-to-many.
+- Child: the table that holds the foreign key in a one-to-many or many-to-one.
+- Link row: a row in the generated junction table for many-to-many relationships.
+
+#### Defaults
+
+- Many-to-one / one-to-one (singular field creates the foreign key on this table):
+    - Default is `ON DELETE RESTRICT`.
+- One-to-many (parent has list of children; child table holds the foreign key):
+    - Default is `ON DELETE RESTRICT` on the child’s foreign key.
+- Many-to-many (both sides declare lists, emitter creates a junction):
+    - Junction foreign keys default to `ON DELETE CASCADE` on both sides.
+    - Effect: deleting a parent or a child deletes only the corresponding link rows; the other side’s table rows are not deleted.
+
+#### Overrides
+
+- Per-relationship field, support a precise override via `on_delete="cascade" | "restrict" | "set_null"`:
+    - Where to specify:
+        - Many-to-one / one-to-one: on the singular field (the table that holds the foreign key).
+        - One-to-many: on the parent list field or on the child’s singular back-reference (if present). Precedence: child’s singular field override wins; otherwise use the parent list field override; otherwise default.
+        - Many-to-many: on either list field to change the junction behavior for that side only. The emitter maps:
+            - `members: list[User] = field(on_delete="restrict")` → junction foreign key on `team_id` uses `ON DELETE RESTRICT`; the other side remains `CASCADE` unless overridden there as well.
+    - Validations:
+        - `set_null` is only valid when the foreign key column is nullable (the emitter errors if not).
+        - `on_delete` on an embedded field is invalid (error).
+        - Conflicting overrides (for example both sides specify different behaviors for the same foreign key): the side that controls the actual foreign key wins. For a junction, each side controls its own foreign key.
+
+#### Effects per relationship type
+
+- Many-to-one / one-to-one:
+    - cascade: deleting the referenced parent deletes the child row.
+    - restrict: deletion of the parent is blocked while child rows exist.
+    - set_null: deleting the parent sets the child’s foreign key to null (requires nullable).
+- One-to-many:
+    - Applies to the foreign key on the child table (as above).
+    - If the parent sets `on_delete="cascade"` on the list field, deleting the parent deletes all children.
+- Many-to-many:
+    - Default junction behavior is “clean up links only”: `ON DELETE CASCADE` on both foreign keys.
+    - Overrides allow “no automatic cleanup” for one side by switching that side’s junction foreign key to `RESTRICT`. There is no `set_null` for junctions (junction columns are non-nullable).
+
+### Examples (in `.mb/schema.py`)
+
+- Many-to-many (default link cleanup only)
+
+```python
+from uuid import UUID
+from mbcore.vendored_dataclass import dataclass, field
+
+@dataclass(db=True, schema="public")
+class Team:
+    id: UUID = field()
+    name: str = field()
+    members: list["User"] = field()  # generates junction table team_user
+
+@dataclass(db=True, schema="public")
+class User:
+    id: UUID = field()
+    email: str = field()
+    teams: list[Team] = field()      # mirrors Team.members
+```
+
+Generated behavior:
+
+- Junction table `team_user(team_id, user_id, unique(team_id, user_id))`.
+- `ON DELETE CASCADE` on both `team_id` and `user_id` in the junction.
+- Deleting a Team removes its `team_user` links, but does not delete User rows; and vice versa.
+
+- Many-to-one with cascade
+
+```python
+from uuid import UUID
+from mbcore.vendored_dataclass import dataclass, field
+
+@dataclass(db=True, schema="public")
+class User:
+    id: UUID = field()
+    email: str = field()
+
+@dataclass(db=True, schema="public")
+class Profile:
+    id: UUID = field()
+    user: "User" = field(on_delete="cascade")
+    settings: dict = field(embed=True)
+```
+
+Generated behavior:
+
+- Profile has `user_id` referencing `user(id)` with `ON DELETE CASCADE`.
+- Deleting a User cascades and deletes Profile rows.
+- `settings` is `jsonb` (embedded), not part of relations.
+
+- One-to-many with explicit set_null
+
+```python
+from uuid import UUID
+from mbcore.vendored_dataclass import dataclass, field
+
+@dataclass(db=True, schema="public")
+class Project:
+    id: UUID = field()
+    name: str = field()
+    tasks: list["Task"] = field(on_delete="set_null")
+
+@dataclass(db=True, schema="public")
+class Task:
+    id: UUID = field()
+    project: "Project | None" = field(default=None)  # nullable for set_null
+    title: str = field()
+```
+
+Generated behavior:
+
+- Task has `project_id` referencing `project(id)` with `ON DELETE SET NULL`.
+- Deleting a Project sets `Task.project_id` to null (allowed because the field is nullable).
+
+### Migration emission and application
+
+- Emission writes SQL to `.mb/supabase/migrations/<timestamp>_<slug>.sql` and a snapshot to `.mb/supabase/schema.json`. Emitted SQL includes `CREATE TABLE`, `ALTER TABLE`, `CREATE TYPE`, `CREATE INDEX`, and foreign keys with `ON DELETE` exactly as above. Destructive changes are blocked unless explicitly allowed.
+- Application: `mb db push --database-url $MB_TEST_DATABASE_URL` applies migrations in order to the target test database. Push never generates schema; it only applies committed SQL.
+
+### Ownership and permissions
+
+- Dataclasses never set roles, grants, or row-level security.
+- Policy packs live in `.mb/policy/<env>.sql` and define ownership (`ALTER TABLE … OWNER TO …`), grants, and row-level security. CI/CD selects the environment policy and applies it after migrations. Team-based or public access rules are encoded here, and CI/CD is authoritative.

--- a/docs/engineering/runbooks/dev/supabase.md
+++ b/docs/engineering/runbooks/dev/supabase.md
@@ -1,0 +1,82 @@
+# Supabase Login, Corporate Auth UI, and Table Observability
+
+## CLI Login (Non-Interactive)
+
+Requirements:
+- Supabase account + Personal Access Token
+- Supabase CLI (macOS): `brew install supabase/tap/supabase`
+
+Steps:
+"""bash
+# 1) Login without browser (token-only)
+SUPABASE_ACCESS_TOKEN=<YOUR_TOKEN> supabase login --no-open
+
+# 2) List projects (copy the project ref)
+supabase projects list
+
+# 3) Link this directory to a project (optional but recommended)
+supabase link --project-ref <PROJECT_REF>
+
+# 4) App environment (never commit secrets)
+export SUPABASE_URL="https://<PROJECT_REF>.supabase.co"
+export SUPABASE_ANON_KEY="<ANON_PUBLIC_KEY>"
+# Optional (server-only):
+# export SUPABASE_SERVICE_ROLE_KEY="<SERVICE_ROLE_KEY>"
+"""
+
+Helper script in this repo:
+"""bash
+./scripts/supabase_login.sh <YOUR_TOKEN>
+# or
+SUPABASE_ACCESS_TOKEN=<YOUR_TOKEN> ./scripts/supabase_login.sh
+"""
+
+## Serve a UI for Corporate Login
+
+Use Supabase Auth UI or your own login page, backed by OAuth providers.
+
+1) In Supabase Dashboard
+- Authentication → Providers: enable e.g. Google (or your IdP)
+- Configure OAuth app credentials; restrict to your company domain
+- Authentication → URL settings: set Site URL and allowed Redirect URLs
+
+2) Frontend (example: React)
+- Install: `npm i @supabase/supabase-js @supabase/auth-ui-react @supabase/auth-ui-shared`
+- Ensure `SUPABASE_URL` and `SUPABASE_ANON_KEY` are exposed to the frontend
+- Render Auth UI (e.g., with Google button). Protect routes using session state
+
+Notes
+- For strict corporate-only access, enforce domain restriction in the OAuth provider
+- For SAML/Entra/Okta (Enterprise), use Supabase SSO (SAML) setup
+
+## Basic Table Observability (UI)
+
+Use Supabase Studio (Table Editor):
+- Hosted: open your project in the Supabase Dashboard → Table Editor
+- CLI: `supabase projects list` and open from dashboard
+
+Local stack (optional):
+"""bash
+# Start local Supabase (Docker required)
+supabase start
+# Open Studio
+supabase open studio   # usually http://127.0.0.1:54323
+# Inspect status / ports
+supabase status
+"""
+
+With Studio you can:
+- Browse tables/schemas/relations
+- Inspect and edit rows
+- View auth users and policies
+- Run SQL via the editor
+
+## Quick Verification
+"""bash
+# Verify CLI login
+supabase projects list
+
+# Verify app envs are set (example for web apps)
+# SUPABASE_URL=https://<PROJECT_REF>.supabase.co
+# SUPABASE_ANON_KEY=eyJhbGciOi...
+"""

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Welcome to the Mbodi Company Handbook! This is our central repository for company information, processes, and guidelines.
 
-The name *mbodi* is derived from *embody*, reflecting our vision to give form to abstract AI capabilities, and the *n-body* problem in physics—representing our first principles approach to achieving embodied general intelligence.
+The name *mbodi* is derived from *embody*, reflecting our vision to give form to practical AI capabilities that work in the real world.
 
 ## Quick Links
 


### PR DESCRIPTION
This adds the Overview for the database schema emission design (dataclasses → Supabase migrations).\n\nScope:\n- Source of truth: .mb/schema.py, db=True, optional schema, embed=True→jsonb\n- Conventions and types\n- Relationship inference (one-to-one, one-to-many, many-to-many with automatic junction)\n- Deletion/cascade rules with defaults and per-field overrides\n- Concrete examples (many-to-many, many-to-one cascade, one-to-many set_null)\n- Migration emission and mb db push application flow\n- Ownership & permissions handled by CI/CD via .mb/policy/<env>.sql\n\nNote: This document is the Overview. A follow-up will specify the exact classes, API, and implementation considerations.